### PR TITLE
Spawn a child process

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ greelight is a graceful health check agent.
 ## Usage
 
 ```
-Usage: greenlight --config="greenlight.yaml"
+Usage: greenlight --config="greenlight.yaml" [<child-cmds> ...]
+
+Arguments:
+  [<child-cmds> ...]
 
 Flags:
   -h, --help                        Show context-sensitive help.
-  -c, --config="greenlight.yaml"    config file path or URL(http,https,file,s3)
-                                    ($GREENLIGHT_CONFIG)
+  -c, --config="greenlight.yaml"    config file path or URL(http,https,file,s3) ($GREENLIGHT_CONFIG)
   -d, --debug                       debug mode ($GREENLIGHT_DEBUG)
       --version                     show version
 ```
@@ -18,6 +20,20 @@ Flags:
 greenlight works as a health check agent for your application.
 
 greenlight checks your application's health by `startup` and `readiness` checks.
+
+## Spawn a child processe
+
+greenlight can spawn a child process (optional).
+
+```conosole
+$ greenlight --config=greenlight.yaml -- /path/to/your/app
+```
+
+greenlight spawns a child process at first.
+
+When greenlight catch a signal (SIGTERM and SIGINT), greenlight sends SIGTERM to the child process, and waits for the child process to exit. If the child process does not exit in 30 seconds, greenlight sends SIGKILL to the child process.
+
+STDOUT and STDERR of the child process are redirected to greenlight's STDOUT and STDERR.
 
 ### startup
 

--- a/cli.go
+++ b/cli.go
@@ -1,7 +1,8 @@
 package greenlight
 
 type CLI struct {
-	Config  string `help:"config file path or URL(http,https,file,s3)" short:"c" required:"true" default:"greenlight.yaml" env:"GREENLIGHT_CONFIG"`
-	Debug   bool   `help:"debug mode" short:"d" default:"false" env:"GREENLIGHT_DEBUG"`
-	Version bool   `help:"show version"`
+	Config    string   `help:"config file path or URL(http,https,file,s3)" short:"c" required:"true" default:"greenlight.yaml" env:"GREENLIGHT_CONFIG"`
+	Debug     bool     `help:"debug mode" short:"d" default:"false" env:"GREENLIGHT_DEBUG"`
+	Version   bool     `help:"show version"`
+	ChildCmds []string `arg:"" optional:"true"`
 }

--- a/cmd/greenlight/main.go
+++ b/cmd/greenlight/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/alecthomas/kong"
 	"github.com/fujiwara/greenlight"
@@ -11,9 +14,11 @@ import (
 var Version = "dev"
 
 func main() {
-	ctx := context.TODO()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	if err := run(ctx); err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/examples/greenlight.yaml
+++ b/examples/greenlight.yaml
@@ -1,4 +1,5 @@
 startup:
+  grace_period: 3s
   checks:
     - name: "memcached alive"
       tcp:
@@ -9,11 +10,11 @@ startup:
         quit: "QUIT\n"
     - name: "app server is up"
       command:
-        run: 'curl -s -o /dev/null -w "%{http_code}" http://localhost:3000'
+        run: 'curl -s -o /dev/null -w "%{http_code}" http://localhost:8000'
     - &web
       name: "web server is ok"
       http:
-        url: "http://localhost:80/"
+        url: "http://localhost:8000/"
         expect_code: 200-399
 readiness:
   checks:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fujiwara/greenlight
 go 1.21
 
 require (
+	github.com/Songmu/wrapcommander v0.1.0
 	github.com/alecthomas/kong v0.8.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.39
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Songmu/wrapcommander v0.1.0 h1:y8/yk9/PHT983weH+ehZIOJ7JtwAlI1AkfUpUNCj1SY=
+github.com/Songmu/wrapcommander v0.1.0/go.mod h1:EC2y4OnN8PkdMnaCwcSzItewq+f0yqUvS30kcS4vmn0=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
 github.com/alecthomas/assert/v2 v2.1.0/go.mod h1:b/+1DI2Q6NckYi+3mXyH3wFb8qG37K/DuK80n7WefXA=
 github.com/alecthomas/kong v0.8.0 h1:ryDCzutfIqJPnNn0omnrgHLbAggDQM2VWHikE1xqK7s=

--- a/responder.go
+++ b/responder.go
@@ -28,6 +28,7 @@ func NewResponder(cfg *ResponderConfig) (*Responder, chan Signal) {
 
 func (r *Responder) Run(ctx context.Context) error {
 	r.logger.Info("starting responder")
+	defer r.logger.Info("responder exited")
 	srv := http.Server{
 		Addr:    r.addr,
 		Handler: r.handler(),
@@ -39,7 +40,11 @@ func (r *Responder) Run(ctx context.Context) error {
 	go r.signalLisetener(ctx)
 
 	r.logger.Info(fmt.Sprintf("listening on %s", r.addr))
-	return srv.ListenAndServe()
+	if err := srv.ListenAndServe(); err != nil {
+		r.logger.Error("failed to listen and serve", slog.String("error", err.Error()))
+		return err
+	}
+	return nil
 }
 
 func (r *Responder) setCurrentSignal(s Signal) {


### PR DESCRIPTION
## Spawn a child processe

greenlight can spawn a child process (optional).

```conosole
$ greenlight --config=greenlight.yaml -- /path/to/your/app
```

greenlight spawns a child process at first.

When greenlight catch a signal (SIGTERM and SIGINT), greenlight sends SIGTERM to the child process, and waits for the child process to exit. If the child process does not exit in 30 seconds, greenlight sends SIGKILL to the child process.

STDOUT and STDERR of the child process are redirected to greenlight's STDOUT and STDERR.
